### PR TITLE
Add ability for platform admins to approve/deny a store

### DIFF
--- a/app/controllers/platform_admin/base_controller.rb
+++ b/app/controllers/platform_admin/base_controller.rb
@@ -1,0 +1,3 @@
+class PlatformAdmin::BaseController < ApplicationController
+
+end

--- a/app/controllers/platform_admin/stores_controller.rb
+++ b/app/controllers/platform_admin/stores_controller.rb
@@ -1,0 +1,12 @@
+class PlatformAdmin::StoresController < ApplicationController
+  def index
+    @stores = Store.all
+  end
+
+  def update
+    @store = Store.find(params[:id])
+    @store.update_attributes(approval: params[:approved])
+    redirect_to platform_admin_stores_path
+    flash[:notice] = "You successfully modified the approval for #{@store.name}"
+  end
+end

--- a/app/controllers/platform_admin/users_controller.rb
+++ b/app/controllers/platform_admin/users_controller.rb
@@ -1,0 +1,5 @@
+class PlatformAdmin::UsersController < ApplicationController
+  def show
+    @user = current_user
+  end
+end

--- a/app/controllers/store_admin/base_controller.rb
+++ b/app/controllers/store_admin/base_controller.rb
@@ -1,3 +1,3 @@
-class Orders::BaseController < ApplicationController
+class StoreAdmin::BaseController < ApplicationController
 
 end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,6 +1,6 @@
 class StoresController < ApplicationController
   def index
-    @stores = Store.all
+    @stores = Store.approved
   end
 
   def show

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -4,6 +4,8 @@ class Store < ActiveRecord::Base
 
   before_create :set_slug
 
+  scope :approved, -> { where(approval: true)}
+
   def set_slug
     self.slug = name.parameterize
   end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -33,6 +33,8 @@ private
 
   def platform_admin_permissions
     return true if @controller == "users" && @action.in?(%w(show edit update))
+    return true if @controller == "platform_admin/stores" && @action.in?(%w(index edit update))
+    return true if @controller == "platform_admin/users" && @action.in?(%w(show))
     store_admin_permissions
 
   end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -16,6 +16,11 @@
       <li>
         <a href="/stores">Stores</a>
       </li>
+      <li>
+        <% if platform_admin? %>
+          <%= link_to "Platform Admin Dashboard", platform_admin_dashboard_path %>
+        <% end %>
+      </li>
       <% if admin? %>
       <li>
         <a href="/store_admin/users">Users</a>

--- a/app/views/platform_admin/stores/index.html.erb
+++ b/app/views/platform_admin/stores/index.html.erb
@@ -1,0 +1,13 @@
+<h1>View and Update All Stores</h1>
+
+<% @stores.each do | store | %>
+  <p><%= store.name %>
+    <%= form_for([:platform_admin, store]) do |f| %>
+    <%= radio_button_tag(:approved, "true")  %>
+    <%= label_tag(:approved_true, "Approve") %>
+    <%= radio_button_tag(:approved, "false")  %>
+    <%= label_tag(:approved_false, "Deny") %>
+    <%= f.submit  %>
+  <% end %>
+  </p>
+<% end %>

--- a/app/views/platform_admin/users/show.html.erb
+++ b/app/views/platform_admin/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Platform Admin Dashboard</h1>
+<%= link_to "View and Modify Stores", platform_admin_stores_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create]
 
+  namespace :platform_admin do
+    resources :stores, only: [:index, :update]
+    get "/dashboard", to: "users#show"
+  end
+
   namespace :store_admin do
     resources :orders, only: [:index, :show, :update]
     resources :users,  only: [:index, :show]

--- a/db/migrate/20160404001049_add_approval_to_stores.rb
+++ b/db/migrate/20160404001049_add_approval_to_stores.rb
@@ -1,0 +1,5 @@
+class AddApprovalToStores < ActiveRecord::Migration
+  def change
+    add_column :stores, :approval, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160402233338) do
+ActiveRecord::Schema.define(version: 20160404001049) do
 
   create_table "items", force: true do |t|
     t.string   "name"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20160402233338) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug"
+    t.boolean  "approval",   default: false
   end
 
   add_index "stores", ["user_id"], name: "index_stores_on_user_id"


### PR DESCRIPTION
Stores can now be approved or denied by a platform admin through the admin's platform dashboard.

Implementing this also affected the navbar (adding a new dashboard) and added a new column (approval) to the store table.
Default approval is false. A scope was also added to the store table to return only approved stores.
